### PR TITLE
update dependencies and build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ During the compile process dbb compiles the common and util classes.
 - bitcoin-core (included as git submodule)
 - openssl
 - https://github.com/signal11/hidapi
+- [boost](http://www.boost.org/)
 - libevent2 (if daemon enabled)
 - qt5 (if UI enabled)
 
 OSX:
 
-    brew install hidapi libevent qt5
+    brew install hidapi libevent qt5 boost
 
 Linux (Ubuntu 15.04):
 
@@ -121,7 +122,7 @@ if libhidapi is not available, compile it yourself
 Basic build steps:
 
     git submodule update --init --recursive
-    ./autogen
+    ./autogen.sh
     ./configure --enable-debug --enable-daemon --with-gui=qt5
     make
     sudo make install


### PR DESCRIPTION
Minor changes I needed for building on OSX.

I didn't test on linux, but from google, instructions for boost ubuntu install:
https://stackoverflow.com/questions/12578499/how-to-install-boost-on-ubuntu
`sudo apt-get install libboost-all-dev`

This apt-get is not in this PR, but I can add it and update the PR.
